### PR TITLE
Separate two types of GET Route Actions from GetResourceAction

### DIFF
--- a/src/main/java/routeActions/AllowOptionsAction.java
+++ b/src/main/java/routeActions/AllowOptionsAction.java
@@ -1,6 +1,5 @@
 package routeActions;
 
-import request.HTTPMethod;
 import request.HTTPRequest;
 import response.EntityHeaderFields;
 import response.HTTPResponse;
@@ -10,10 +9,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static request.HTTPMethod.OPTIONS;
 import static response.EntityHeaderFields.ALLOW;
 import static response.HTTPStatusCode.OK;
 
 public class AllowOptionsAction implements RouteAction {
+
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return request.method() == OPTIONS;
+    }
 
     @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {

--- a/src/main/java/routeActions/DeleteResourceAction.java
+++ b/src/main/java/routeActions/DeleteResourceAction.java
@@ -4,9 +4,15 @@ import request.HTTPRequest;
 import response.HTTPResponse;
 import router.Router;
 
+import static request.HTTPMethod.DELETE;
 import static response.HTTPStatusCode.OK;
 
 public class DeleteResourceAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return request.method() == DELETE;
+    }
+
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
         response.setStatusLine(request.version(), OK);

--- a/src/main/java/routeActions/DirectoryContentsAction.java
+++ b/src/main/java/routeActions/DirectoryContentsAction.java
@@ -4,9 +4,15 @@ import request.HTTPRequest;
 import response.HTTPResponse;
 import router.Router;
 
+import static request.HTTPMethod.GET;
 import static response.HTTPStatusCode.OK;
 
 public class DirectoryContentsAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return request.method() == GET;
+    }
+
     @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();

--- a/src/main/java/routeActions/GETResourceAction.java
+++ b/src/main/java/routeActions/GETResourceAction.java
@@ -1,111 +1,23 @@
 package routeActions;
 
 import request.HTTPRequest;
-import response.EntityHeaderFields;
 import response.HTTPResponse;
 import router.Router;
 
-import java.util.*;
-
-import static response.EntityHeaderFields.CONTENT_RANGE;
-import static response.EntityHeaderFields.RANGE;
+import static request.HTTPMethod.GET;
 import static response.HTTPStatusCode.OK;
-import static response.HTTPStatusCode.PARTIAL_CONTENT;
 
 public class GETResourceAction implements RouteAction {
     @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return request.method() == GET;
+    }
+
+    @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
-        setHeadersAndBody(response, request, uriProcessor);
+        response.setStatusLine(request.version(), OK);
+        response.setBody(uriProcessor.read(request.uri().uri()));
         return response;
-    }
-
-    private HTTPResponse setHeadersAndBody(HTTPResponse response, HTTPRequest request, URIProcessor uriProcessor) {
-        byte[] payload = uriProcessor.read(request.uri().uri());
-        if (getPartialContentRequest(request)) {
-            response.setStatusLine(request.version(), PARTIAL_CONTENT);
-            Integer[] startAndEndIndexes = getStartAndEndIndexes(payload, request);
-            response.setBody(getPartialContent(payload, startAndEndIndexes));
-            return response;
-        }
-        else {
-            response.setStatusLine(request.version(), OK);
-            response.setBody(payload);
-            return response;
-        }
-    }
-
-    private byte[] getPartialContent(byte[] payload, Integer[] startAndEndIndexes) {
-        return Arrays.copyOfRange(payload, startAndEndIndexes[0], endPosition(payload.length, startAndEndIndexes[1]));
-    }
-
-    private String[] parseByteRange(HTTPRequest request) {
-        String[] range = request.headers().get(RANGE).split("=");
-        return range[1].split("-");
-    }
-
-    private Integer[] getStartAndEndIndexes(byte[] entirePayload, HTTPRequest request) {
-        String[] startAndEndByteRange = parseByteRange(request);
-        Integer[] startAndEndPositions;
-        if (startAndEndByteProvided(startAndEndByteRange)) {
-            startAndEndPositions = new Integer[]{convertToInt(startAndEndByteRange[0]), oneIndexed(convertToInt(startAndEndByteRange[1]))};
-        } else if (reversedStartByteProvided(startAndEndByteRange)) {
-            startAndEndPositions = new Integer[]{reverseStartPosition(entirePayload, startAndEndByteRange[1]), entirePayload.length};
-        } else if (startByteOnlyProvided(startAndEndByteRange)) {
-            startAndEndPositions = new Integer[]{convertToInt(startAndEndByteRange[0]), entirePayload.length};
-        } else {
-            startAndEndPositions = new Integer[]{0, 0};
-        }
-        return startAndEndPositions;
-    }
-
-    private byte[] extractPartialContent(byte[] entirePayload, String[] startAndEndBytes) {
-        Integer[] startAndEndPositions;
-        if (startAndEndByteProvided(startAndEndBytes)) {
-            startAndEndPositions = new Integer[]{convertToInt(startAndEndBytes[0]), oneIndexed(convertToInt(startAndEndBytes[1]))};
-        } else if (reversedStartByteProvided(startAndEndBytes)) {
-            startAndEndPositions = new Integer[]{reverseStartPosition(entirePayload, startAndEndBytes[1]), entirePayload.length};
-        } else if (startByteOnlyProvided(startAndEndBytes)) {
-            startAndEndPositions = new Integer[]{convertToInt(startAndEndBytes[0]), entirePayload.length};
-        } else {
-            startAndEndPositions = new Integer[]{0, 0};
-        }
-        return Arrays.copyOfRange(entirePayload, startAndEndPositions[0], endPosition(entirePayload.length, startAndEndPositions[1]));
-    }
-
-    private int oneIndexed(int zeroIndexPosition) {
-        return zeroIndexPosition + 1;
-    }
-
-    private int reverseStartPosition(byte[] payload, String startPosition) {
-        return payload.length - convertToInt(startPosition);
-    }
-
-    private boolean startAndEndByteProvided(String[] startAndEndBytes) {
-        return startAndEndBytes.length == 2 && !startAndEndBytes[0].equals("");
-    }
-
-    private boolean reversedStartByteProvided(String[] startAndEndBytes) {
-        return startAndEndBytes.length == 2 && startAndEndBytes[0].equals("");
-    }
-
-    private boolean startByteOnlyProvided(String[] startAndEndBytes) {
-        return startAndEndBytes.length == 1 && convertToInt(startAndEndBytes[0]) != 0;
-    }
-
-    private int convertToInt(String value) {
-        try {
-            return Integer.valueOf(value);
-        } catch (Exception e) {
-            return 0;
-        }
-    }
-
-    private int endPosition(int payloadLength, int endPosition) {
-        return (payloadLength - endPosition) <= 0 ? payloadLength : endPosition;
-    }
-
-    private boolean getPartialContentRequest(HTTPRequest request) {
-        return request.headers() != null && request.headers().containsKey(RANGE);
     }
 }

--- a/src/main/java/routeActions/MethodNotAllowedAction.java
+++ b/src/main/java/routeActions/MethodNotAllowedAction.java
@@ -1,6 +1,5 @@
 package routeActions;
 
-import request.HTTPMethod;
 import request.HTTPRequest;
 import response.EntityHeaderFields;
 import response.HTTPResponse;
@@ -15,6 +14,11 @@ import static response.EntityHeaderFields.ALLOW;
 import static response.HTTPStatusCode.METHOD_NOT_ALLOWED;
 
 public class MethodNotAllowedAction implements RouteAction{
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
     @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();

--- a/src/main/java/routeActions/ParameterDecodeAction.java
+++ b/src/main/java/routeActions/ParameterDecodeAction.java
@@ -11,6 +11,11 @@ import static response.HTTPStatusCode.OK;
 
 public class ParameterDecodeAction implements RouteAction {
     @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
+    @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
         response.setStatusLine(request.version(), OK);

--- a/src/main/java/routeActions/PartialContentAction.java
+++ b/src/main/java/routeActions/PartialContentAction.java
@@ -1,0 +1,98 @@
+package routeActions;
+
+import request.HTTPRequest;
+import response.EntityHeaderFields;
+import response.HTTPResponse;
+import router.Router;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static response.EntityHeaderFields.CONTENT_RANGE;
+import static response.EntityHeaderFields.RANGE;
+import static response.HTTPStatusCode.PARTIAL_CONTENT;
+
+public class PartialContentAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return getPartialContentRequest(request);
+    }
+
+    @Override
+    public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
+        HTTPResponse response = new HTTPResponse();
+        byte[] payload = uriProcessor.read(request.uri().uri());
+        response.setStatusLine(request.version(), PARTIAL_CONTENT);
+        response.setBody(getPartialContent(payload, getStartAndEndIndexes(payload, request)));
+        return response;
+    }
+
+    private boolean getPartialContentRequest(HTTPRequest request) {
+        return request.headers() != null && request.headers().containsKey(RANGE);
+    }
+
+    private String[] parseByteRange(HTTPRequest request) {
+        String[] range = request.headers().get(RANGE).split("=");
+        return range[1].split("-");
+    }
+
+    private Integer[] getStartAndEndIndexes(byte[] entirePayload, HTTPRequest request) {
+        String[] startAndEndByteRange = parseByteRange(request);
+        Integer[] startAndEndPositions;
+        if (startAndEndByteProvided(startAndEndByteRange)) {
+            int startIndex = convertToInt(startAndEndByteRange[0]);
+            int endIndex = oneIndexed(convertToInt(startAndEndByteRange[1]));
+            startAndEndPositions = createStartAndEndRange(startIndex, endIndex);
+        } else if (reversedStartByteProvided(startAndEndByteRange)) {
+            startAndEndPositions = createStartAndEndRange(reverseStartPosition(entirePayload, startAndEndByteRange[1]), entirePayload.length);
+        } else if (startByteOnlyProvided(startAndEndByteRange)) {
+            startAndEndPositions = createStartAndEndRange(convertToInt(startAndEndByteRange[0]), entirePayload.length);
+        } else {
+            startAndEndPositions = createStartAndEndRange(0, 0);
+        }
+        return startAndEndPositions;
+    }
+
+    private Integer[] createStartAndEndRange(int startIndex, int endIndex) {
+        return new Integer[]{startIndex, endIndex};
+    }
+
+    private byte[] getPartialContent(byte[] payload, Integer[] startAndEndIndexes) {
+        return Arrays.copyOfRange(payload, startAndEndIndexes[0], endPosition(payload.length, startAndEndIndexes[1]));
+    }
+
+    private int oneIndexed(int zeroIndexPosition) {
+        return zeroIndexPosition + 1;
+    }
+
+    private int reverseStartPosition(byte[] payload, String startPosition) {
+        return payload.length - convertToInt(startPosition);
+    }
+
+    private boolean startAndEndByteProvided(String[] startAndEndBytes) {
+        return startAndEndBytes.length == 2 && !startAndEndBytes[0].equals("");
+    }
+
+    private boolean reversedStartByteProvided(String[] startAndEndBytes) {
+        return startAndEndBytes.length == 2 && startAndEndBytes[0].equals("");
+    }
+
+    private boolean startByteOnlyProvided(String[] startAndEndBytes) {
+        return startAndEndBytes.length == 1 && convertToInt(startAndEndBytes[0]) != 0;
+    }
+
+    private int convertToInt(String value) {
+        try {
+            return Integer.valueOf(value);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private int endPosition(int payloadLength, int endPosition) {
+        return (payloadLength - endPosition) <= 0 ? payloadLength : endPosition;
+    }
+}

--- a/src/main/java/routeActions/RouteAction.java
+++ b/src/main/java/routeActions/RouteAction.java
@@ -5,5 +5,7 @@ import response.HTTPResponse;
 import router.Router;
 
 public interface RouteAction {
+    boolean isAppropriate(HTTPRequest request);
+
     HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor);
 }

--- a/src/main/java/routeActions/StatusNOKAction.java
+++ b/src/main/java/routeActions/StatusNOKAction.java
@@ -7,6 +7,11 @@ import router.Router;
 import static response.HTTPStatusCode.NOT_FOUND;
 
 public class StatusNOKAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
         response.setStatusLine(request.version(), NOT_FOUND);

--- a/src/main/java/routeActions/StatusOKAction.java
+++ b/src/main/java/routeActions/StatusOKAction.java
@@ -7,6 +7,12 @@ import router.Router;
 import static response.HTTPStatusCode.OK;
 
 public class StatusOKAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
+    @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
         response.setStatusLine(request.version(), OK);

--- a/src/main/java/routeActions/UpdateResourceAction.java
+++ b/src/main/java/routeActions/UpdateResourceAction.java
@@ -2,14 +2,20 @@ package routeActions;
 
 import request.HTTPRequest;
 import response.HTTPResponse;
-import response.HTTPStatusCode;
 import router.Router;
+
+import static response.HTTPStatusCode.OK;
 
 public class UpdateResourceAction implements RouteAction {
     @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
+    @Override
     public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
         HTTPResponse response = new HTTPResponse();
-        response.setStatusLine(request.version(), HTTPStatusCode.OK);
+        response.setStatusLine(request.version(), OK);
         uriProcessor.create(request.uri().uri(), request.body());
         return response;
     }

--- a/src/main/java/router/RouteProcessor.java
+++ b/src/main/java/router/RouteProcessor.java
@@ -2,7 +2,10 @@ package router;
 
 import request.HTTPRequest;
 import response.HTTPResponse;
+import routeActions.RouteAction;
 import routeActions.URIProcessor;
+
+import java.util.List;
 
 public class RouteProcessor {
     private final Router router;
@@ -14,8 +17,11 @@ public class RouteProcessor {
     }
 
     public HTTPResponse buildResponse(HTTPRequest request) {
-        return router
-                .findRouteActions(request)
+        return selectRouteAction(router.findRouteActions(request), request)
                 .generateResponse(request, router, uriProcessor);
+    }
+
+    private RouteAction selectRouteAction(List<RouteAction> routeActions, HTTPRequest request) {
+        return routeActions.stream().filter(routeAction -> routeAction.isAppropriate(request)).findFirst().get();
     }
 }

--- a/src/main/java/router/Router.java
+++ b/src/main/java/router/Router.java
@@ -6,28 +6,28 @@ import routeActions.MethodNotAllowedAction;
 import routeActions.RouteAction;
 import routeActions.StatusNOKAction;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
-public class Router {
-    private final Map<Route, RouteAction> routeActions;
+import static java.util.Collections.singletonList;
 
-    public Router(Map<Route, RouteAction> routeActions) {
+public class Router {
+    private final Map<Route, List<RouteAction>> routeActions;
+
+    public Router(Map<Route, List<RouteAction>> routeActions) {
         this.routeActions = routeActions;
     }
 
-    public RouteAction findRouteActions(HTTPRequest request) {
-        for (Entry<Route, RouteAction> entry : routeActions.entrySet()) {
+    public List<RouteAction> findRouteActions(HTTPRequest request) {
+        for (Entry<Route, List<RouteAction>> entry : routeActions.entrySet()) {
             if (entry.getKey().isMatch(request)) {
                 return entry.getValue();
             }
         }
         if (!resourceNotFound(request.uri())) {
-            return new StatusNOKAction();
+            return singletonList(new StatusNOKAction());
         } else {
-            return new MethodNotAllowedAction();
+            return singletonList(new MethodNotAllowedAction());
         }
     }
 
@@ -37,7 +37,7 @@ public class Router {
 
     public List<String> allowedMethods(HTTPResource resource) {
         List<String> methods = new ArrayList<>();
-        for (Entry<Route, RouteAction> entry : routeActions.entrySet()) {
+        for (Entry<Route, List<RouteAction>> entry : routeActions.entrySet()) {
             if (entry.getKey().resource().uri().equals(resource.uri())) {
                 methods.add(entry.getKey().method().method());
             }

--- a/src/main/java/router/RoutesFactory.java
+++ b/src/main/java/router/RoutesFactory.java
@@ -2,36 +2,51 @@ package router;
 
 import routeActions.*;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
+import static java.util.Arrays.asList;
 import static request.HTTPMethod.*;
 import static request.HTTPResource.*;
 import static request.HTTPVersion.HTTP_1_1;
 
 public class RoutesFactory {
-    public Map<Route, RouteAction> routeActions() {
-        Map<Route, RouteAction> routeActions = new HashMap<>();
-        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(GET, INDEX, HTTP_1_1), new DirectoryContentsAction());
-        routeActions.put(new Route(GET, FORM, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(PUT, FORM, HTTP_1_1), new UpdateResourceAction());
-        routeActions.put(new Route(POST, FORM, HTTP_1_1), new UpdateResourceAction());
-        routeActions.put(new Route(GET, FILE1, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, IMAGEJPEG, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, IMAGEPNG, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, IMAGEGIF, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, PARAMETERS, HTTP_1_1), new ParameterDecodeAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), new AllowOptionsAction());
-        routeActions.put(new Route(GET, OPTIONS_ONE, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(PUT, OPTIONS_ONE, HTTP_1_1), new UpdateResourceAction());
-        routeActions.put(new Route(POST, OPTIONS_ONE, HTTP_1_1), new UpdateResourceAction());
-        routeActions.put(new Route(HEAD, OPTIONS_ONE, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), new AllowOptionsAction());
-        routeActions.put(new Route(GET, OPTIONS_TWO, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, TEXT_FILE, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(GET, PARTIAL_CONTENT, HTTP_1_1), new GETResourceAction());
-        routeActions.put(new Route(DELETE, FORM, HTTP_1_1), new DeleteResourceAction());
+    public Map<Route, List<RouteAction>> routeActions() {
+        Map<Route, List<RouteAction>> routeActions = new HashMap<>();
+        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), asList(new StatusOKAction()));
+        routeActions.put(new Route(GET, INDEX, HTTP_1_1), asList(new DirectoryContentsAction()));
+        routeActions.put(new Route(GET, FORM, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(PUT, FORM, HTTP_1_1), asList(new UpdateResourceAction()));
+        routeActions.put(new Route(POST, FORM, HTTP_1_1), asList(new UpdateResourceAction()));
+        routeActions.put(new Route(GET, FILE1, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(GET, IMAGEJPEG, HTTP_1_1), asList(new GETResourceAction()));
+        routeActions.put(new Route(GET, IMAGEPNG, HTTP_1_1), asList(new GETResourceAction()));
+        routeActions.put(new Route(GET, IMAGEGIF, HTTP_1_1), asList(new GETResourceAction()));
+        routeActions.put(new Route(GET, PARAMETERS, HTTP_1_1), asList(
+                new ParameterDecodeAction(),
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), asList(new AllowOptionsAction()));
+        routeActions.put(new Route(GET, OPTIONS_ONE, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(PUT, OPTIONS_ONE, HTTP_1_1), asList(new UpdateResourceAction()));
+        routeActions.put(new Route(POST, OPTIONS_ONE, HTTP_1_1), asList(new UpdateResourceAction()));
+        routeActions.put(new Route(HEAD, OPTIONS_ONE, HTTP_1_1), asList(new StatusOKAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), asList(new AllowOptionsAction()));
+        routeActions.put(new Route(GET, OPTIONS_TWO, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(GET, TEXT_FILE, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(GET, PARTIAL_CONTENT, HTTP_1_1), asList(
+                new PartialContentAction(),
+                new GETResourceAction()));
+        routeActions.put(new Route(DELETE, FORM, HTTP_1_1), asList(new DeleteResourceAction()));
         return routeActions;
     }
 }

--- a/src/main/java/server/HttpServerMain.java
+++ b/src/main/java/server/HttpServerMain.java
@@ -9,6 +9,7 @@ import router.RoutesFactory;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.List;
 import java.util.Map;
 
 public class HttpServerMain {
@@ -42,7 +43,7 @@ public class HttpServerMain {
         return arguments;
     }
 
-    private static Map<Route, RouteAction> routeActions() {
+    private static Map<Route, List<RouteAction>> routeActions() {
         return new RoutesFactory().routeActions();
     }
 }

--- a/src/test/java/routeActions/GETResourceActionTest.java
+++ b/src/test/java/routeActions/GETResourceActionTest.java
@@ -15,12 +15,11 @@ import testHelper.TestHelpers;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static request.HTTPMethod.GET;
 import static request.HTTPResource.FORM;
-import static request.HTTPResource.PARTIAL_CONTENT;
 import static request.HTTPVersion.HTTP_1_1;
 
 public class GETResourceActionTest {
@@ -51,49 +50,6 @@ public class GETResourceActionTest {
         HTTPResponse response = new GETResourceAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
 
         assertEquals(content, response.getBody());
-    }
-
-    @Test
-    public void partialContentResponse() {
-        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
-        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
-
-        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=0-4"));
-        HTTPResponse response = new GETResourceAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
-
-        assertEquals("This ", response.getBody());
-    }
-
-    @Test
-    public void partialContentEndRangeResponse() {
-        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
-        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
-
-        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=-6"));
-        HTTPResponse response = new GETResourceAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
-
-        assertEquals("a 206.", response.getBody());
-    }
-
-    @Test
-    public void partialContentStartRangeGivenResponse() {
-        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
-        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
-
-        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=4-"));
-        HTTPResponse response = new GETResourceAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
-
-        assertEquals(" is a file that contains text to read part of in order to fulfill a 206.", response.getBody());
-    }
-
-    private String payloadContent() {
-        return "This is a file that contains text to read part of in order to fulfill a 206.";
-    }
-
-    private Map<EntityHeaderFields, String> partialContentRangeHeader(String range) {
-        Map<EntityHeaderFields, String> headers = new HashMap<>();
-        headers.put(EntityHeaderFields.RANGE, range);
-        return headers;
     }
 
     private HTTPRequest newGETRequest(HTTPMethod method, HTTPResource uri, HTTPVersion version, Map<EntityHeaderFields, String> headerFields) {

--- a/src/test/java/routeActions/PartialContentActionTest.java
+++ b/src/test/java/routeActions/PartialContentActionTest.java
@@ -1,0 +1,89 @@
+package routeActions;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import request.HTTPMethod;
+import request.HTTPRequest;
+import request.HTTPResource;
+import request.HTTPVersion;
+import response.EntityHeaderFields;
+import response.HTTPResponse;
+import router.RouterStub;
+import testHelper.TestHelpers;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static request.HTTPMethod.GET;
+import static request.HTTPResource.PARTIAL_CONTENT;
+import static request.HTTPVersion.*;
+
+public class PartialContentActionTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private File rootFolder;
+    private TestHelpers testHelpers;
+    private String testFolder;
+
+    @Before
+    public void setUp() {
+        testFolder = "test";
+        testHelpers = new TestHelpers();
+        try {
+            rootFolder = temporaryFolder.newFolder(testFolder);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    @Test
+    public void partialContentResponse() {
+        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
+        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
+
+        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=0-4"));
+        HTTPResponse response = new PartialContentAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
+
+        assertEquals("This ", response.getBody());
+    }
+
+    @Test
+    public void partialContentEndRangeResponse() {
+        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
+        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
+
+        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=-6"));
+        HTTPResponse response = new PartialContentAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
+
+        assertEquals("a 206.", response.getBody());
+    }
+
+    @Test
+    public void partialContentStartRangeGivenResponse() {
+        testHelpers.createFileAtResource(rootFolder, "/partial_content.txt", payloadContent());
+        URIProcessor uriProcessor = new URIProcessor(testHelpers.pathToRootFolder(temporaryFolder, testFolder));
+
+        HTTPRequest getRequest = newGETRequest(GET, PARTIAL_CONTENT, HTTP_1_1, partialContentRangeHeader("bytes=4-"));
+        HTTPResponse response = new PartialContentAction().generateResponse(getRequest, new RouterStub(), uriProcessor);
+
+        assertEquals(" is a file that contains text to read part of in order to fulfill a 206.", response.getBody());
+    }
+
+    private String payloadContent() {
+        return "This is a file that contains text to read part of in order to fulfill a 206.";
+    }
+
+    private Map<EntityHeaderFields, String> partialContentRangeHeader(String range) {
+        Map<EntityHeaderFields, String> headers = new HashMap<>();
+        headers.put(EntityHeaderFields.RANGE, range);
+        return headers;
+    }
+
+    private HTTPRequest newGETRequest(HTTPMethod method, HTTPResource uri, HTTPVersion version, Map<EntityHeaderFields, String> headerFields) {
+        return new HTTPRequest(method, uri, version, null, headerFields, null);
+    }
+}

--- a/src/test/java/router/RouteProcessorTest.java
+++ b/src/test/java/router/RouteProcessorTest.java
@@ -6,12 +6,13 @@ import request.HTTPMethod;
 import request.HTTPRequest;
 import request.HTTPResource;
 import request.HTTPVersion;
-import response.EntityHeaderFields;
 import response.HTTPResponse;
 import routeActions.RouteAction;
 import routeActions.StatusOKAction;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -20,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import static request.HTTPMethod.*;
 import static request.HTTPResource.*;
 import static request.HTTPVersion.HTTP_1_1;
+import static response.EntityHeaderFields.ALLOW;
 
 public class RouteProcessorTest {
     private String statusLineOKResponse;
@@ -67,8 +69,14 @@ public class RouteProcessorTest {
         HTTPResponse response = routeProcessor.buildResponse(request);
         String methodNotFoundResponse = "HTTP/1.1 405 Method Not Allowed";
         assertEquals(methodNotFoundResponse, response.getStatusLine());
-        assertThat(response.getEntityHeaders().get(EntityHeaderFields.ALLOW), hasItem(PUT.method()));
-        assertThat(response.getEntityHeaders().get(EntityHeaderFields.ALLOW), hasItem(POST.method()));
+        assertThat(response.getEntityHeaders().get(ALLOW), hasItem(PUT.method()));
+        assertThat(response.getEntityHeaders().get(ALLOW), hasItem(POST.method()));
+    }
+
+    @Test
+    public void appropriateRouteActionFromSelection() {
+
+
     }
 
     private HTTPRequest createRequest(HTTPMethod method, HTTPResource uri, String queryParams, HTTPVersion version) {
@@ -84,14 +92,14 @@ public class RouteProcessorTest {
         return requestLine;
     }
 
-    public Map<Route, RouteAction> routeActions() {
-        Map<Route, RouteAction> routeActions = new HashMap<>();
-        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(GET, INDEX, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(PUT, FORM, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(POST, FORM, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), new StatusOKAction());
+    public Map<Route, List<RouteAction>> routeActions() {
+        Map<Route, List<RouteAction>> routeActions = new HashMap<>();
+        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), Arrays.asList(new StatusOKAction()));
+        routeActions.put(new Route(GET, INDEX, HTTP_1_1), Arrays.asList(new StatusOKAction()));
+        routeActions.put(new Route(PUT, FORM, HTTP_1_1), Arrays.asList(new StatusOKAction()));
+        routeActions.put(new Route(POST, FORM, HTTP_1_1), Arrays.asList(new StatusOKAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), Arrays.asList(new StatusOKAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), Arrays.asList(new StatusOKAction()));
         return routeActions;
     }
 }

--- a/src/test/java/router/RouterFake.java
+++ b/src/test/java/router/RouterFake.java
@@ -14,7 +14,7 @@ public class RouterFake extends Router {
     }
 
     @Override
-    public RouteAction findRouteActions(HTTPRequest request) {
+    public List<RouteAction> findRouteActions(HTTPRequest request) {
         return null;
     }
 

--- a/src/test/java/router/RouterTest.java
+++ b/src/test/java/router/RouterTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -40,48 +41,48 @@ public class RouterTest {
     @Test
     public void fourOhFourResponse() {
         HTTPRequest request = unknownResourceRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusFourOhFourResponse, response.getStatusLine());
     }
 
     @Test
     public void methodNotAllowedResponse() {
         HTTPRequest request = bogusMethodRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusMethodNotAllowedResponse, response.getStatusLine());
     }
 
     @Test
     public void okActionForGETRequest() {
         HTTPRequest request = knownResourceGETRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusOKResponse, response.getStatusLine());
     }
 
     @Test
     public void okActionForPOSTRequest() {
         HTTPRequest request = knownResourcePOSTRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusOKResponse, response.getStatusLine());
     }
 
     @Test
     public void okActionForPUTRequest() {
         HTTPRequest request = knownResourcePUTRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusOKResponse, response.getStatusLine());
     }
 
     @Test
     public void okActionForHEADRequest() {
         HTTPRequest request = knownResourceHEADRequest();
-        RouteAction action = router.findRouteActions(request);
-        HTTPResponse response = action.generateResponse(request, router, uriProcessorStub);
+        List<RouteAction> actions = router.findRouteActions(request);
+        HTTPResponse response = actions.get(0).generateResponse(request, router, uriProcessorStub);
         assertEquals(statusOKResponse, response.getStatusLine());
     }
 
@@ -94,14 +95,14 @@ public class RouterTest {
         assertThat(methods, hasItem(PUT.method()));
     }
 
-    public Map<Route, RouteAction> routeActions() {
-        Map<Route, RouteAction> routeActions = new HashMap<>();
-        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(GET, INDEX, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(PUT, FORM, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(POST, FORM, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), new StatusOKAction());
-        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), new StatusOKAction());
+    public Map<Route, List<RouteAction>> routeActions() {
+        Map<Route, List<RouteAction>> routeActions = new HashMap<>();
+        routeActions.put(new Route(HEAD, INDEX, HTTP_1_1), singletonList(new StatusOKAction()));
+        routeActions.put(new Route(GET, INDEX, HTTP_1_1), singletonList(new StatusOKAction()));
+        routeActions.put(new Route(PUT, FORM, HTTP_1_1), singletonList(new StatusOKAction()));
+        routeActions.put(new Route(POST, FORM, HTTP_1_1), singletonList(new StatusOKAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_ONE, HTTP_1_1), singletonList(new StatusOKAction()));
+        routeActions.put(new Route(OPTIONS, OPTIONS_TWO, HTTP_1_1), singletonList(new StatusOKAction()));
         return routeActions;
     }
 

--- a/src/test/java/server/HttpServerTest.java
+++ b/src/test/java/server/HttpServerTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import routeActions.RouteAction;
 import router.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,7 +41,7 @@ public class HttpServerTest {
         assertEquals(true, executorServiceSpy.hasSubmittedATask());
     }
 
-    private Map<Route, RouteAction> routes() {
+    private Map<Route, List<RouteAction>> routes() {
         return new RoutesFactory().routeActions();
     }
 


### PR DESCRIPTION
GETResourceAction was doing both a normal GET and a PartialContent GET.
I don't love having to maintain the order of RouteActions in RoutesFactory for GETs
, nor do I love having the isAppropriate check, but it's the simplest resolution
at the moment.
