### PR TITLE
Basic Auth with hardcoded body

### DIFF
--- a/src/main/java/request/HTTPResource.java
+++ b/src/main/java/request/HTTPResource.java
@@ -9,14 +9,18 @@ public enum HTTPResource {
     IMAGEJPEG("/image.jpeg"),
     IMAGEPNG("/image.png"),
     IMAGEGIF("/image.gif"),
+    LOGS("/logs"),
+    LOG("/log"),
     OPTIONS_ONE("/method_options"),
     OPTIONS_TWO("/method_options2"),
     PARAMETERS("/parameters"),
     PARTIAL_CONTENT("/partial_content.txt"),
     PATCH_CONTENT("/patch-content.txt"),
     REDIRECT("/redirect"),
+    REQUESTS("/requests"),
     TEA("/tea"),
     TEXT_FILE("/text-file.txt"),
+    THESE("/these"),
     UNRECOGNIZED("");
 
     private final String uri;

--- a/src/main/java/response/EntityHeaderFields.java
+++ b/src/main/java/response/EntityHeaderFields.java
@@ -2,6 +2,7 @@ package response;
 
 public enum EntityHeaderFields {
     ALLOW("Allow"),
+    AUTHORIZATION("Authorization"),
     CONTENT_LENGTH("Content-Length"),
     CONTENT_RANGE("Content-Range"),
     CONTENT_LOCATION("Content-Location"),
@@ -9,6 +10,7 @@ public enum EntityHeaderFields {
     IF_MATCH("If-Match"),
     LOCATION("Location"),
     RANGE("Range"),
+    AUTHENTICATE("WWW-Authenticate"),
     INVALID_HEADER("INVALID_HEADER");
 
     private final String field;

--- a/src/main/java/response/HTTPStatusCode.java
+++ b/src/main/java/response/HTTPStatusCode.java
@@ -5,6 +5,7 @@ public enum HTTPStatusCode {
     NO_CONTENT(204, "No Content"),
     PARTIAL_CONTENT(206, "Partial Content"),
     FOUND(302, "Found"),
+    UNAUTHORIZED(401, "Unauthorized"),
     NOT_FOUND(404, "Not Found"),
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
     PRECONDITION_FAILED(412, "Precondition Failed"),

--- a/src/main/java/routeActions/AuthenticateAction.java
+++ b/src/main/java/routeActions/AuthenticateAction.java
@@ -1,0 +1,69 @@
+package routeActions;
+
+import request.HTTPRequest;
+import response.EntityHeaderFields;
+import response.HTTPResponse;
+import response.ResponseHTTPMessageFormatter;
+import router.Router;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static request.HTTPVersion.HTTP_1_1;
+import static response.EntityHeaderFields.AUTHENTICATE;
+import static response.EntityHeaderFields.AUTHORIZATION;
+import static response.HTTPStatusCode.OK;
+import static response.HTTPStatusCode.UNAUTHORIZED;
+
+public class AuthenticateAction implements RouteAction {
+    @Override
+    public boolean isAppropriate(HTTPRequest request) {
+        return true;
+    }
+
+    @Override
+    public HTTPResponse generateResponse(HTTPRequest request, Router router, URIProcessor uriProcessor) {
+        return isAuthorized(request) ? createProtectionSpaceResponse() : createUnauthorizedResponse();
+    }
+
+    private HTTPResponse createUnauthorizedResponse() {
+        return new HTTPResponse(new ResponseHTTPMessageFormatter())
+                .setStatusLine(HTTP_1_1, UNAUTHORIZED)
+                .setEntityHeaders(unauthorizedHeaders());
+    }
+
+    private HTTPResponse createProtectionSpaceResponse() {
+        return new HTTPResponse(new ResponseHTTPMessageFormatter())
+                .setStatusLine(HTTP_1_1, OK)
+                .setBody(documentProtectionSpace().getBytes());
+    }
+
+    private boolean isAuthorized(HTTPRequest request) {
+        if (request.headers().containsKey(AUTHORIZATION)) {
+            return parseAuthorization(request.headers().get(AUTHORIZATION)).equals("admin:hunter2");
+        }
+        return false;
+    }
+
+    private String parseAuthorization(String authorizationValue) {
+        String encodedCredentials = getEncodedCredentials(authorizationValue);
+        return new String(Base64.getDecoder().decode(encodedCredentials.trim()));
+    }
+
+    private String documentProtectionSpace() {
+        return String.format("%s\n%s\n%s\n", "GET /log HTTP/1.1", "PUT /these HTTP/1.1", "HEAD /requests HTTP/1.1");
+    }
+
+    private Map<EntityHeaderFields, List<String>> unauthorizedHeaders() {
+        Map<EntityHeaderFields, List<String>> headers = new HashMap<>();
+        headers.put(AUTHENTICATE, asList("Basic realm='WallyWorld'"));
+        return headers;
+    }
+
+    private String getEncodedCredentials(String authorizationValue) {
+        return authorizationValue.split(" ")[1];
+    }
+}

--- a/src/main/java/routeActions/PatchContentAction.java
+++ b/src/main/java/routeActions/PatchContentAction.java
@@ -1,4 +1,4 @@
-package router;
+package routeActions;
 
 import request.HTTPRequest;
 import response.EntityHeaderFields;
@@ -6,6 +6,7 @@ import response.HTTPResponse;
 import response.ResponseHTTPMessageFormatter;
 import routeActions.RouteAction;
 import routeActions.URIProcessor;
+import router.Router;
 
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;

--- a/src/main/java/router/RoutesFactory.java
+++ b/src/main/java/router/RoutesFactory.java
@@ -2,7 +2,9 @@ package router;
 
 import routeActions.*;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static request.HTTPMethod.*;
@@ -51,6 +53,10 @@ public class RoutesFactory {
         routeActions.put(new Route(GET, COFFEE, HTTP_1_1), asList(new IAmATeapotAction()));
         routeActions.put(new Route(GET, TEA, HTTP_1_1), asList(new IAmATeapotAction()));
         routeActions.put(new Route(GET, REDIRECT, HTTP_1_1), asList(new RedirectPathAction()));
+        routeActions.put(new Route(GET, LOGS, HTTP_1_1), asList(new AuthenticateAction()));
+        routeActions.put(new Route(GET, LOG, HTTP_1_1), asList(new AuthenticateAction()));
+        routeActions.put(new Route(PUT, THESE, HTTP_1_1), asList(new AuthenticateAction()));
+        routeActions.put(new Route(HEAD, REQUESTS, HTTP_1_1), asList(new AuthenticateAction()));
         routeActions.put(new Route(DELETE, FORM, HTTP_1_1), asList(new DeleteResourceAction()));
         return routeActions;
     }

--- a/src/test/java/routeActions/AuthenticateActionTest.java
+++ b/src/test/java/routeActions/AuthenticateActionTest.java
@@ -1,0 +1,69 @@
+package routeActions;
+
+import org.junit.Before;
+import org.junit.Test;
+import request.HTTPRequest;
+import response.EntityHeaderFields;
+import response.HTTPResponse;
+import router.RouterStub;
+import router.URIProcessorStub;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static request.HTTPMethod.GET;
+import static request.HTTPResource.LOGS;
+import static request.HTTPVersion.HTTP_1_1;
+import static response.EntityHeaderFields.*;
+import static response.HTTPStatusCode.OK;
+
+public class AuthenticateActionTest {
+
+    private AuthenticateAction action;
+
+    @Before
+    public void setUp() {
+        action = new AuthenticateAction();
+    }
+
+    @Test
+    public void authenticationCanBeAppliedToAnyRoute() {
+        assertEquals(true, action.isAppropriate(new HTTPRequest()));
+    }
+
+    @Test
+    public void requestReceivedWithoutCredentials() {
+        HTTPRequest request = new HTTPRequest(GET, LOGS, HTTP_1_1, null, emptyCredentials(), null);
+        HTTPResponse response = action.generateResponse(request, new RouterStub(), new URIProcessorStub());
+        assertEquals(true, response.getEntityHeaders().containsKey(AUTHENTICATE));
+    }
+
+    @Test
+    public void requestReceivedWithCredentials() {
+        HTTPRequest request = new HTTPRequest(GET, LOGS, HTTP_1_1, null, base64Credentials(), null);
+        HTTPResponse response = action.generateResponse(request, new RouterStub(), new URIProcessorStub());
+        assertEquals(OK, response.getStatusCode());
+    }
+
+    @Test
+    public void authorizedRequestRespondsWithBody() {
+        HTTPRequest request = new HTTPRequest(GET, LOGS, HTTP_1_1, null, base64Credentials(), null);
+        HTTPResponse response = action.generateResponse(request, new RouterStub(), new URIProcessorStub());
+        assertEquals(expectedBodyContainsProtectionSpace(), new String(response.getBody()));
+    }
+
+    private String expectedBodyContainsProtectionSpace() {
+        return String.format("%s\n%s\n%s\n", "GET /log HTTP/1.1", "PUT /these HTTP/1.1", "HEAD /requests HTTP/1.1");
+    }
+
+    private Map<EntityHeaderFields, String> base64Credentials() {
+        Map<EntityHeaderFields, String> headers = new HashMap<>();
+        headers.put(AUTHORIZATION, "Basic YWRtaW46aHVudGVyMg==");
+        return headers;
+    }
+
+    private Map<EntityHeaderFields,String> emptyCredentials() {
+        return new HashMap<>();
+    }
+}


### PR DESCRIPTION
I couldn't find any mention in the HTTP specs about sending back a body with
what I assume is the 'protection space', and the acceptance test doesn't
force the GET /log, HEAD /requests etc to fail unless authorized.  I have presumed
that it is the case though.
Also, the AuthenticateAction feels like it should have some configuration values e.g
for the 'admin:hunter' details and the name of the 'realm'.
